### PR TITLE
fix TimeLoop `resume` method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,9 @@ export default class TimeLoop {
 
     if (!this.started) {
       this.started = true;
-      window.requestAnimationFrame(this.proxyStep);
     }
+
+    window.requestAnimationFrame(this.proxyStep);
   }
 
   /**


### PR DESCRIPTION
move `window.requestAnimationFrame(this.proxyStep);` outside the `if started` condition.
